### PR TITLE
Update documentation for v0.5.0 npm CLI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 </p>
 
 <p align="center">
+  <a href="https://www.npmjs.com/package/@rickywo/formic"><img src="https://img.shields.io/npm/v/@rickywo/formic?style=flat-square&logo=npm&color=CB3837" alt="npm"></a>
   <a href="#quickstart"><img src="https://img.shields.io/badge/Docker-Ready-2496ED?style=flat-square&logo=docker" alt="Docker Ready"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=flat-square" alt="MIT License"></a>
   <img src="https://img.shields.io/badge/Version-0.5.0-blue?style=flat-square" alt="Version 0.5.0">
@@ -77,7 +78,34 @@
 
 ---
 
-## 🆕 What's New in v0.4.0
+## 🆕 What's New in v0.5.0
+
+### 📦 npm Global Install — Run Formic Anywhere
+
+Formic is now available on npm. Install globally and run in any project directory with a single command.
+
+```bash
+# Install globally
+npm install -g @rickywo/formic
+
+# Initialize and start in any project
+cd your-project
+formic init
+formic start
+```
+
+**CLI Commands:**
+| Command | Description |
+|---------|-------------|
+| `formic init` | Initialize Formic in the current directory (creates `.formic/`) |
+| `formic start` | Start the Formic server (default: port 8000) |
+| `formic start --port 3000` | Start on a custom port |
+| `formic --help` | Show help and available commands |
+| `formic --version` | Show version number |
+
+---
+
+## What's New in v0.4.0
 
 ### 🗂️ Multi-Workspace Support — Switch Projects Seamlessly
 
@@ -178,7 +206,21 @@ Queue tasks from anywhere and let the agents work while you sleep. No buttons to
 
 ## Quickstart
 
-### 🐳 One Command
+### 📦 npm (Recommended)
+
+```bash
+# Install globally
+npm install -g @rickywo/formic
+
+# In your project directory
+cd your-project
+formic init
+formic start
+```
+
+Open `http://localhost:8000` and start creating tasks.
+
+### 🐳 Docker
 
 ```bash
 docker run -p 8000:8000 \
@@ -186,8 +228,6 @@ docker run -p 8000:8000 \
   -e ANTHROPIC_API_KEY=your-api-key \
   ghcr.io/your-org/formic:latest
 ```
-
-Open `http://localhost:8000` and start creating tasks.
 
 ### Three Steps to Autonomous Development
 
@@ -383,7 +423,12 @@ npm start
 
 ## Roadmap
 
-### v0.4.0 (Current)
+### v0.5.0 (Current)
+- [x] **npm Global Install** — Install via `npm install -g @rickywo/formic`
+- [x] **CLI Commands** — `formic init` and `formic start` for easy setup
+- [x] **Portable Package** — Works in any project directory
+
+### v0.4.0
 - [x] **Multi-Workspace Support** — Switch between projects without restarting
 - [x] **Multiple Task Creation** — AI can create multiple tasks in a single response
 - [x] **GitHub Copilot Integration** — Full AI Task Manager support for Copilot CLI

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,11 +1,12 @@
-# Product Specification: Formic v0.4.0
+# Product Specification: Formic v0.5.0
 
 ## 1. Executive Summary
 
 | Attribute | Value |
 |-----------|-------|
 | Product Name | Formic |
-| Version | 0.4.0 |
+| Version | 0.5.0 |
+| npm Package | `@rickywo/formic` |
 | Type | Local-First Agent Orchestration & Execution Environment |
 | Target Audience | Developers using AI coding agents for project development |
 | Supported Agents | Claude Code CLI, GitHub Copilot CLI |
@@ -27,7 +28,15 @@ Formic supports multiple AI coding agents through a unified abstraction layer:
 
 Both agents support the same skill format (`SKILL.md` with YAML frontmatter), enabling seamless switching between agents without workflow changes.
 
-### v0.4.0 New Features
+### v0.5.0 New Features
+
+| Feature | Description |
+|---------|-------------|
+| **npm Global Install** | Install via `npm install -g @rickywo/formic` for easy global access |
+| **CLI Commands** | `formic init` initializes a project, `formic start` launches the server |
+| **Portable Package** | Works in any project directory without cloning the repository |
+
+### v0.4.0 Features
 
 | Feature | Description |
 |---------|-------------|
@@ -611,6 +620,68 @@ interface WorkspaceInfo {
 ```typescript
 // Broadcast to all clients on workspace change
 { "type": "workspace_changed", "path": "/new/workspace/path" }
+```
+
+### 2.13 CLI Interface
+
+Formic v0.5.0 introduces a CLI for easy installation and usage via npm.
+
+**Installation:**
+```bash
+npm install -g @rickywo/formic
+```
+
+**CLI Commands:**
+
+| Command | Description |
+|---------|-------------|
+| `formic init` | Initialize Formic in the current directory (creates `.formic/`) |
+| `formic start` | Start the Formic server on default port (8000) |
+| `formic start --port <n>` | Start server on custom port |
+| `formic --help` | Show help message |
+| `formic --version` | Show version number |
+
+**Architecture:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│  $ formic init                                              │
+│                         ↓                                   │
+│  Creates .formic/ directory with:                           │
+│  ├── board.json (empty board)                               │
+│  └── tasks/ (empty directory)                               │
+│                                                             │
+│  $ formic start                                             │
+│                         ↓                                   │
+│  1. Loads .env file from workspace (if exists)              │
+│  2. Validates .formic/ directory exists                     │
+│  3. Calls startServer({ port, workspacePath })              │
+│  4. Server starts at http://localhost:8000                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Environment Variables:**
+
+The CLI automatically loads environment variables from a `.env` file in the workspace directory:
+
+```bash
+# .env file in your project
+ANTHROPIC_API_KEY=your-api-key
+AGENT_TYPE=claude
+PORT=8000
+```
+
+**Programmatic Usage:**
+
+The server can also be started programmatically:
+
+```typescript
+import { startServer } from '@rickywo/formic';
+
+await startServer({
+  port: 3000,
+  host: '0.0.0.0',
+  workspacePath: '/path/to/project'
+});
 ```
 
 ### 2.14 Agent Abstraction Layer
@@ -1213,6 +1284,22 @@ services:
 - [x] Implement stall detection for manual testing subtasks
 - [x] Add 'skipped' status for non-automatable subtasks
 - [x] Improve UI visibility (workspace input, panel layouts)
+
+### Phase 17: npm Package & CLI ✅
+- [x] Create CLI entry point (`src/cli/index.ts`)
+- [x] Implement `formic init` command to initialize projects
+- [x] Implement `formic start` command to launch server
+- [x] Add `--port` flag for custom port configuration
+- [x] Export `startServer()` function for programmatic use
+- [x] Centralize path resolution for global npm installs
+- [x] Add `ServerOptions` type for CLI configuration
+- [x] Prepare `package.json` for npm publishing:
+  - Add `bin` entry for CLI command
+  - Add `files` array for package contents
+  - Remove `private: true` flag
+  - Add npm metadata (keywords, repository, homepage)
+- [x] Publish to npm as `@rickywo/formic`
+- [x] Add MIT LICENSE file
 
 ---
 


### PR DESCRIPTION
## Summary

Updates README.md and SPEC.md to document the new npm CLI feature released in v0.5.0.

## Changes

### README.md
- Add npm badge linking to `@rickywo/formic` package
- Add "What's New in v0.5.0" section featuring:
  - npm global install instructions
  - CLI commands table (`formic init`, `formic start`)
- Update Quickstart section to prioritize npm install over Docker
- Update Roadmap with v0.5.0 as current version

### SPEC.md
- Update version from 0.4.0 to 0.5.0
- Add `npm Package: @rickywo/formic` to Executive Summary
- Add v0.5.0 features section
- Add section 2.13 CLI Interface with:
  - Installation instructions
  - CLI commands table
  - Architecture diagram
  - Environment variables documentation
  - Programmatic usage example
- Add Phase 17 (npm Package & CLI) to Development Roadmap

## npm Install Instructions (Now Prominent in README)

```bash
npm install -g @rickywo/formic
cd your-project
formic init
formic start
```

🤖 Generated with [Claude Code](https://claude.ai/code)